### PR TITLE
Upgrade pdf lib and fix generation issues

### DIFF
--- a/drafthorse/__init__.py
+++ b/drafthorse/__init__.py
@@ -1,1 +1,1 @@
-version = "2.2.1"
+version = "2.2.2"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 lxml
-PyPDF2
+pypdf
 pytest
 flake8
 isort

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "Programming Language :: Python :: 3.10",
     ],
     keywords="xml banking sepa",
-    install_requires=["lxml", "PyPDF2"],
+    install_requires=["lxml", "pypdf"],
     packages=find_packages(include=["drafthorse", "drafthorse.*"]),
     include_package_data=True,
 )


### PR DESCRIPTION
- Switch from PyPDF2 -> pypdf
	- The PyPDF2 project is going back to its roots. PyPDF2==3.0.X will be the last version of PyPDF2. Development will continue with [pypdf==3.1.0](https://pypi.org/project/pyPdf/).
- Fix output intents generation
	- getObject is deprecated and was removed. therefore, output intents were missing from the output pdf. get_object shall be used instead
	- it can be checked via https://www.pdf-online.com/osa/validate.aspx
- Fix NameObject generation error; e
	- NameObject error is raised every time you generate an invoice; therefore, replace NameObject with create_string_object for the metadata size field
- Add logging to pdf generation